### PR TITLE
/.idea в .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### IntelliJ IDEA ###
+/.idea/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/


### PR DESCRIPTION
Добавление /.idea в .gitignore связано с тем, что эта папка создаётся средой разработки IntelliJ IDEA и содержит локальные настройки проекта. В этой папке хранятся файлы конфигурации, такие как workspace.xml, modules.xml, кэш IDE и персональные настройки запуска. Эти файлы специфичны для рабочего окружения и не нужны другим разработчикам. Если не добавить /.idea в .gitignore, возможны конфликты при коммитах, особенно когда несколько человек работают в одной IDE. Репозиторий должен содержать только исходный код и общие настройки проекта, а не временные или локальные файлы IDE.